### PR TITLE
feat: use viam-labs:service:chat API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .pyprojectx/
+module.tar.gz

--- a/README.md
+++ b/README.md
@@ -28,20 +28,24 @@ The following is an example configuration for this resource's attributes based o
 
 ## Usage
 
-This module is built as a [Generic component](https://docs.viam.com/components/generic/#api) that follows a single command called "chat" through the [`DoCommand` / `do_command` method](https://docs.viam.com/components/generic/#docommand)
+This module is built as a [Chat service](https://github.com/viam-labs/chat-service-api) that has a single method called "chat".
 
 ```python
+from chat_service_api import Chat
+
 // machine connection logic above
 
-llm = Generic.from_robot(robot, name="llm")
-response = await llm.do_command({"chat": ["What is the meaning of life?"]})
-print(response["chat"])
+llm = Chat.from_robot(robot, name="llm")
+response = await llm.chat("What is the meaning of life?")
+print(response)
 ```
 
 ```go
-llm, err := generic.FromRobot(robot, "llm")
-resp, err := llm.DoCommand(ctx, map[string]interface{}{"chat": ["What is the meaning of life?"]})
-fmt.Println(resp["chat"])
+import chat "github.com/viam-labs/chat-service-api/src/chat_go"
+
+llm, err := chat.FromRobot(robot, "llm")
+resp, err := llm.Chat(ctx, "What is the meaning of life?")
+fmt.Println(resp)
 ```
 
 See the [`examples/client.py`](./examples/client.py) for a complete demo program.

--- a/examples/client.py
+++ b/examples/client.py
@@ -1,8 +1,9 @@
 import asyncio
 
 from viam.robot.client import RobotClient
-from viam.components.generic import Generic
 from viam.logging import getLogger
+
+from chat_service_api import Chat
 
 LOGGER = getLogger(__name__)
 
@@ -21,12 +22,12 @@ async def main():
     print('Resources:')
     print(robot.resource_names)
 
-    llm = Generic.from_robot(robot, name="llm")
+    llm = Chat.from_robot(robot, name="llm")
 
     prompt = "Please provide a list of famous robots from history."
-    response =  await llm.do_command({ "chat": [prompt]})
+    response =  await llm.chat(prompt)
     print(f"Prompt: {prompt}")
-    print(f"Answer: {response["chat"]}")
+    print(f"Answer: {response}")
 
     # Don't forget to close the machine when you're done!
     await robot.close()

--- a/meta.json
+++ b/meta.json
@@ -5,8 +5,8 @@
   "description": "A Viam module for inferencing a local LLM.",
   "models": [
     {
-      "api": "viam:component:generic",
-      "model": "viam-labs:generic:llm"
+      "api": "viam-labs:service:chat",
+      "model": "viam-labs:chat:llm"
     }
   ],
   "entrypoint": "run.sh"

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,19 @@
 groups = ["default"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:d54b7973abf97a7846378fa0366746d49e996ceaebadcd9a14e23abe27817442"
+content_hash = "sha256:198e696f4f10287da3a28932bec0bb7962b0731de19ca52bdc3cb7554bf56327"
+
+[[package]]
+name = "chat-service-api"
+version = "0.0.1"
+requires_python = "<3.13"
+git = "https://github.com/viam-labs/chat-service-api.git"
+revision = "bcd6fdd2432901b08bd8c39ccf0c8fe665e0107a"
+summary = "Viam modular service API that provides chat response capabilities"
+groups = ["default"]
+dependencies = [
+    "viam-sdk>=0.13.2",
+]
 
 [[package]]
 name = "diskcache"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "local-llm"
-version = "0.0.1"
+version = "0.1.0"
 description = "A Viam module for inferencing a local LLM."
 authors = [
     {name = "Nick Hehr", email = "nick.hehr@viam.com"},
@@ -9,8 +9,9 @@ dependencies = [
     "llama-cpp-python>=0.2.29",
     "viam-sdk",
     "numpy>=1.26.2",
+    "chat-service-api @ git+https://github.com/viam-labs/chat-service-api.git",
 ]
-requires-python = ">=3.8.1,<3.13"
+requires-python = ">=3.8.2,<3.13"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 

--- a/run.sh
+++ b/run.sh
@@ -33,7 +33,7 @@ if [[ $OS == "Linux" ]]; then
   if command -v clinfo; then
     echo "Setting OpenCL BLAS cmake args"
     export CMAKE_ARGS="-DLLAMA_CLBLAST=ON"
-  elif command -v nvidia-smi: then
+  elif command -v nvidia-smi; then
     echo "Setting Cuda BLAS cmake args"
     export CMAKE_ARGS="-DLLAMA_CUBLAST=ON"
   else

--- a/src/local_llm/__init__.py
+++ b/src/local_llm/__init__.py
@@ -1,6 +1,6 @@
-from viam.components.generic import Generic
 from viam.resource.registry import Registry, ResourceCreatorRegistration
+from chat_service_api import Chat
 
 from .llm import Llm
 
-Registry.register_resource_creator(Generic.SUBTYPE, Llm.MODEL, ResourceCreatorRegistration(Llm.new, Llm.validate_config))
+Registry.register_resource_creator(Chat.SUBTYPE, Llm.MODEL, ResourceCreatorRegistration(Llm.new, Llm.validate_config))

--- a/src/local_llm/__main__.py
+++ b/src/local_llm/__main__.py
@@ -1,13 +1,13 @@
 import asyncio
 
-from viam.components.generic import Generic
 from viam.module.module import Module
+from chat_service_api import Chat
 
 from . import Llm
 
 async def main():
     module = Module.from_args()
-    module.add_model_from_registry(Generic.SUBTYPE, Llm.MODEL)
+    module.add_model_from_registry(Chat.SUBTYPE, Llm.MODEL)
     await module.start()
 
 asyncio.run(main())


### PR DESCRIPTION
To provide a more semantic and consistent developer experience when using the `local-llm` module, this PR updates the implemented API to use the [chat-service-api (`viam-labs:service:chat`)](https://github.com/viam-labs/chat-service-api) instead of the `rdk:component:generic` API. 

This change has been tested as a local module on a smart machine and confirmed working. 