### PR TITLE
fix: use VIAM_MODULE_DATA dir for models, install compilation deps

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ if command -v apt-get; then
       echo "package info not found, trying apt update"
       $SUDO apt-get -qq update
     fi
-    $SUDO apt-get install -qqy python3-venv
+    $SUDO apt-get install -qqy python3-venv cmake make
   fi
 else
   echo "Skipping tool installation because your platform is missing apt-get"
@@ -38,8 +38,17 @@ if [[ $OS == "Linux" ]]; then
     export CMAKE_ARGS="-DLLAMA_CUBLAST=ON"
   else
     echo "Setting OpenBLAS cmake args"
+    $SUDO apt-get install -qqy clang libopenblas-dev
+    export CC="clang"
+    export CXX="clang"
     export CMAKE_ARGS="-DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=OpenBLAS"
   fi
+fi
+
+if [[ $OS == "Darwin" ]]; then
+  echo "Running on MacOS"
+  echo "Setting Metal cmake args"
+  export CMAKE_ARGS="-DLLAMA_METAL=on"
 fi
 
 if [ ! -d "$VIRTUAL_ENV" ]; then

--- a/src/local_llm/llm.py
+++ b/src/local_llm/llm.py
@@ -16,11 +16,14 @@ from chat_service_api import Chat
 from llama_cpp import Llama
 
 LOGGER = getLogger(__name__)
-MODEL_DIR = os.environ.get('MODEL_DIR', os.path.join(os.path.expanduser('~'), '.data', 'models'))
+MODEL_DIR = os.environ.get(
+    "VIAM_MODULE_DATA", os.path.join(os.path.expanduser("~"), ".data", "models")
+)
+
 
 class Llm(Chat, Reconfigurable):
     MODEL: ClassVar[Model] = Model(ModelFamily("viam-labs", "chat"), "llm")
-    LLM_REPO = "" 
+    LLM_REPO = ""
     LLM_FILE = ""
     MODEL_PATH = os.path.abspath(os.path.join(MODEL_DIR, LLM_FILE))
 
@@ -28,7 +31,9 @@ class Llm(Chat, Reconfigurable):
         super().__init__(name)
 
     @classmethod
-    def new(cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]) -> Self:
+    def new(
+        cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]
+    ) -> Self:
         llm = cls(config.name)
         llm.reconfigure(config, dependencies)
         return llm
@@ -37,22 +42,31 @@ class Llm(Chat, Reconfigurable):
     def validate_config(cls, config: ComponentConfig) -> Sequence[str]:
         return []
 
-    def reconfigure(self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]):
+    def reconfigure(
+        self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]
+    ):
         attrs = struct_to_dict(config.attributes)
         LOGGER.info(attrs)
-        self.LLM_REPO = str(attrs.get('llm_repo', "second-state/TinyLlama-1.1B-Chat-v1.0-GGUF"))
-        self.LLM_FILE = str(attrs.get('llm_file', "tinyllama-1.1b-chat-v1.0.Q5_K_M.gguf"))
+        self.LLM_REPO = str(
+            attrs.get("llm_repo", "second-state/TinyLlama-1.1B-Chat-v1.0-GGUF")
+        )
+        self.LLM_FILE = str(
+            attrs.get("llm_file", "tinyllama-1.1b-chat-v1.0.Q5_K_M.gguf")
+        )
         self.MODEL_PATH = os.path.abspath(os.path.join(MODEL_DIR, self.LLM_FILE))
 
         self.get_model()
-        n_gpu_layers = int(attrs.get('n_gpu_layers', 0))
-        self.temperature = float(attrs.get('temperature', 0.75))
-        self.system_message = str(attrs.get('system_message', "A chat between a curious user and an artificial intelligence assistant. The assistant must start by introducing themselves as 'The Great Provider'. The assistant gives helpful, detailed, and polite answers to the user's questions."))
+        n_gpu_layers = int(attrs.get("n_gpu_layers", 0))
+        self.temperature = float(attrs.get("temperature", 0.75))
+        self.system_message = str(
+            attrs.get(
+                "system_message",
+                "A chat between a curious user and an artificial intelligence assistant. The assistant must start by introducing themselves as 'The Great Provider'. The assistant gives helpful, detailed, and polite answers to the user's questions.",
+            )
+        )
         self.llama = Llama(
-                model_path=self.MODEL_PATH,
-                chat_format="chatml",
-                n_gpu_layers=n_gpu_layers
-                )
+            model_path=self.MODEL_PATH, chat_format="chatml", n_gpu_layers=n_gpu_layers
+        )
 
     async def close(self):
         LOGGER.info(f"{self.name} is closed.")
@@ -60,14 +74,8 @@ class Llm(Chat, Reconfigurable):
     async def chat(self, message: str) -> str:
         response = self.llama.create_chat_completion(
             messages=[
-                {
-                    "role": "system",
-                    "content": self.system_message
-                },
-                {
-                    "role": "user",
-                    "content": message
-                }
+                {"role": "system", "content": self.system_message},
+                {"role": "user", "content": message},
             ],
             temperature=self.temperature,
         )
@@ -75,7 +83,9 @@ class Llm(Chat, Reconfigurable):
 
     def get_model(self):
         if not os.path.exists(self.MODEL_PATH):
-            LLM_URL = f"https://huggingface.co/{self.LLM_REPO}/resolve/main/{self.LLM_FILE}"
+            LLM_URL = (
+                f"https://huggingface.co/{self.LLM_REPO}/resolve/main/{self.LLM_FILE}"
+            )
             LOGGER.info(f"Fetching model {self.LLM_FILE} from {LLM_URL}")
             urlretrieve(LLM_URL, self.MODEL_PATH, self.log_progress)
 


### PR DESCRIPTION
After attempting to run this module on [DietPi OS](https://dietpi.com/) as a lighter-weight distribution of Debian than Raspbian, I ran into compilation issues when building the `llama-cpp-python` wheels. I've added those build tools as dependencies for Linux in the `run.sh` entrypoint. I've also updated the default install location for models to standardize on the [`VIAM_MODULE_DATA`](https://docs.viam.com/registry/configure/#default-environment-variables) directory. 